### PR TITLE
[fix] add <x/> element required by XEP-0045

### DIFF
--- a/jabber.py
+++ b/jabber.py
@@ -918,6 +918,7 @@ class Server:
 
         xmpp_room = xmpp.protocol.JID(resource)
         pres = xmpp.Presence(to=xmpp_room)
+        pres.setTag('x', namespace='http://jabber.org/protocol/muc')
 
         self.client.send(pres)
 


### PR DESCRIPTION
[XEP-0045](https://xmpp.org/extensions/xep-0045.html#enter-muc)
[Prosody 0.11.0](https://github.com/bjc/prosody/blob/0.11.0/plugins/muc/muc.lib.lua#L507)+ returns `You must join the room before sending presence updates` error without `<x/>`