### PR TITLE
[fix] encode title with "utf-8" codec before passing to set_title

### DIFF
--- a/jabber.py
+++ b/jabber.py
@@ -752,7 +752,7 @@ class Server:
         if not jid or not body:
             subject = node.getSubject()
             if subject:
-                buddy.chat.set_title(subject)
+                buddy.chat.set_title(subject.encode('utf-8'))
             return
 
         if not buddy:


### PR DESCRIPTION
Without this I get encoding errors in non-ascii conferences